### PR TITLE
Change default keybind only when it's not defined

### DIFF
--- a/PoshCodex/Source/Scripts/Initialize-Module-On-Import.ps1
+++ b/PoshCodex/Source/Scripts/Initialize-Module-On-Import.ps1
@@ -4,9 +4,11 @@
 [Environment]::SetEnvironmentVariable('OLLAMA_MODEL', 'rishi255/posh_codex_model', [System.EnvironmentVariableTarget]::User)
 
 
-if (-not [Environment]::GetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', 'User') {
-  ## Set default keybind, if not already set:
-  
-  $default_keybind = 'Ctrl+Shift+O'
-  Set-CompletionKeybind $null $default_keybind;
+if (-not [Environment]::GetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', 'User')) {
+	## Use default keybind, if none is set
+	$default_keybind = 'Ctrl+Shift+O'
+} else {
+	## Use existing keybind
+	$default_keybind = [Environment]::GetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', 'User')
 }
+Set-CompletionKeybind $null $default_keybind

--- a/PoshCodex/Source/Scripts/Initialize-Module-On-Import.ps1
+++ b/PoshCodex/Source/Scripts/Initialize-Module-On-Import.ps1
@@ -4,7 +4,9 @@
 [Environment]::SetEnvironmentVariable('OLLAMA_MODEL', 'rishi255/posh_codex_model', [System.EnvironmentVariableTarget]::User)
 
 
-## Set default keybind:
-
-$default_keybind = 'Ctrl+Shift+O'
-Set-CompletionKeybind $null $default_keybind;
+if (-not [Environment]::GetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', 'User') {
+  ## Set default keybind, if not already set:
+  
+  $default_keybind = 'Ctrl+Shift+O'
+  Set-CompletionKeybind $null $default_keybind;
+}


### PR DESCRIPTION
This will make the keybind persistent between PoshCodex module imports, so users do not have to change it after every module import with Enter-CompletionKeybind.