### PR TITLE
Code refactoring

### DIFF
--- a/PoshCodex/Source/Private/Convert-KeyPressToString.ps1
+++ b/PoshCodex/Source/Private/Convert-KeyPressToString.ps1
@@ -30,8 +30,8 @@ function Convert-KeyPressToString {
 	# If the Escape key is pressed, exit the loop
 	if ($key.Key -eq 'Escape') {
 		Write-Host 'Aborted by user, exiting...'
-		return $null
+		return
 	}
 
-	return $keybind
+	$keybind
 }

--- a/PoshCodex/Source/Private/Invoke-OllamaApi.ps1
+++ b/PoshCodex/Source/Private/Invoke-OllamaApi.ps1
@@ -1,4 +1,4 @@
-function Invoke-Ollama-Api {
+function Invoke-OllamaApi {
 	[CmdletBinding()]
 	param (
 		$BUFFER
@@ -13,10 +13,11 @@ function Invoke-Ollama-Api {
 		stream = $false
 	}
 
-	$json_output = Invoke-RestMethod -Method POST `
-		-Uri "$ollama_host/api/generate" `
-		-Body ($data | ConvertTo-Json) `
-		-ContentType 'application/json; charset=utf-8';
-
-	return $json_output
+	$splatRestMethod = @{
+		Method      = 'POST'
+		Uri         = "$ollama_host/api/generate"
+		Body        = ConvertTo-Json -InputObject $data
+		ContentType = 'application/json; charset=utf-8'
+	}
+	Invoke-RestMethod @splatRestMethod
 }

--- a/PoshCodex/Source/Private/Set-CompletionKeybind.ps1
+++ b/PoshCodex/Source/Private/Set-CompletionKeybind.ps1
@@ -13,12 +13,15 @@ function Set-CompletionKeybind {
 		Remove-PSReadLineKeyHandler -Chord $old_keybind
 		Write-Host "Previous keybind removed: $old_keybind"
 	}
-	
-	Set-PSReadLineKeyHandler -Chord $new_keybind `
-		-BriefDescription Write-Completion `
-		-LongDescription 'Autocomplete the command' `
-		-ScriptBlock { Write-Completion }
-	
+
+	$splatKeyHandler = @{
+		Chord            = $new_keybind
+		BriefDescription = 'Write-Completion'
+		Description      = 'Autocomplete the command'
+		ScriptBlock      = { Write-Completion }
+	}
+	Set-PSReadLineKeyHandler @splatKeyHandler
+
 	# Update env var with new keybind
-	[Environment]::SetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', $new_keybind, [System.EnvironmentVariableTarget]::User)
+	[Environment]::SetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', $new_keybind, [EnvironmentVariableTarget]::User)
 }

--- a/PoshCodex/Source/Private/Write-Completion.ps1
+++ b/PoshCodex/Source/Private/Write-Completion.ps1
@@ -10,11 +10,11 @@ function Write-Completion {
 
 	# read text from current buffer
 	[Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$BUFFER, [ref]$cursor)
-	
+
 	# If the buffer text itself contains double quotes, then we need to escape them.
 	$BUFFER = $BUFFER.Replace('"', '""')
 
-	$json_output = Invoke-Ollama-Api $BUFFER
+	$json_output = Invoke-OllamaApi $BUFFER
 
 	# check if json_output is not equal to null
 	if ($null -ne $json_output) {
@@ -25,6 +25,6 @@ function Write-Completion {
 		[Microsoft.PowerShell.PSConsoleReadLine]::Insert($completion)
 	}
 	else {
-		Write-Output 'Response returned by API is null! It could be an internal error or the model is not installed properly hrough Ollama. Please fix and try again.' -ForegroundColor Red
+		Write-Host 'Response returned by API is null! It could be an internal error or the model is not installed properly through Ollama. Please fix and try again.' -ForegroundColor Red
 	}
 }

--- a/PoshCodex/Source/Scripts/Initialize-Module-On-Import.ps1
+++ b/PoshCodex/Source/Scripts/Initialize-Module-On-Import.ps1
@@ -5,7 +5,7 @@
 
 $current_keybind = [Environment]::GetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', 'User')
 
-$default_keybind = if (-not [String]::IsNullOrWhiteSpace($current_keybind)) {
+$default_keybind = if ([String]::IsNullOrWhiteSpace($current_keybind)) {
 	## Use default keybind, if none is set
 	'Ctrl+Shift+O'
 } else {

--- a/PoshCodex/Source/Scripts/Initialize-Module-On-Import.ps1
+++ b/PoshCodex/Source/Scripts/Initialize-Module-On-Import.ps1
@@ -1,14 +1,15 @@
 ## Set necessary environment variables:
 
-[Environment]::SetEnvironmentVariable('OLLAMA_HOST', 'http://localhost:11434', [System.EnvironmentVariableTarget]::User)
-[Environment]::SetEnvironmentVariable('OLLAMA_MODEL', 'rishi255/posh_codex_model', [System.EnvironmentVariableTarget]::User)
+[Environment]::SetEnvironmentVariable('OLLAMA_HOST', 'http://localhost:11434', [EnvironmentVariableTarget]::User)
+[Environment]::SetEnvironmentVariable('OLLAMA_MODEL', 'rishi255/posh_codex_model', [EnvironmentVariableTarget]::User)
 
+$current_keybind = [Environment]::GetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', 'User')
 
-if (-not [Environment]::GetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', 'User')) {
+$default_keybind = if (-not [String]::IsNullOrWhiteSpace($current_keybind)) {
 	## Use default keybind, if none is set
-	$default_keybind = 'Ctrl+Shift+O'
+	'Ctrl+Shift+O'
 } else {
 	## Use existing keybind
-	$default_keybind = [Environment]::GetEnvironmentVariable('AUTOCOMPLETE_KEYBIND', 'User')
+	$current_keybind
 }
 Set-CompletionKeybind $null $default_keybind


### PR DESCRIPTION
@rishi255  This PR does following:

1. **Convert-KeyPressToString**
	- Remove redundant `$null` when Escape is pressed
	 - Emmit `$keybind` output directly

2. **Invoke-OllamaApi**
	- Use PowerShell naming convention for private functions
	- Replace backticks with splatting
	- Emit rest method output directly

3. **Write-Completion**
	- Use `Write-Host`, because `Write-Output` does not support colors (did you mean `Write-Error`?)
	- Fix misspelled word in the message
	
4. **Set-CompletionKeybind**
 	- Replace backticks with splatting
 	- Remove redundant `System` namespace reference
 	
5. **Initialize-Module-On-Import**
	- Remove redundant `System` namespace reference
	- Refactor keybind code to not read environment variable twice
	
_I've built and test the module locally._

_PS: If you happy with this PR I can work on another that will start the `Ollama` automatically during module import._
